### PR TITLE
Add coordinator and multi-drone patrol

### DIFF
--- a/main.jcm
+++ b/main.jcm
@@ -1,6 +1,8 @@
 mas main {
 
+agent coord : coordinator.asl
 agent drone1 : drone.asl
+agent drone2 : drone.asl
 
     workspace w {}
 }

--- a/src/agt/coordinator.asl
+++ b/src/agt/coordinator.asl
@@ -1,0 +1,19 @@
+{ include("$jacamo/templates/common-cartago.asl") }
+
+!start.
+
++!start
+ <- makeArtifact("grid","artifacts.PatrolEnv",[500,200,700,500,10],Env);
+    focus(Env);
+    startPatrol.
+    .print("Coordinator ready.").
+
++ready(D)[source(D)]
+ <- +drone(D).
+
++threat(X,Y)
+ <- .broadcast(tell,gather(X,Y)).
+
++neutralized(X,Y)[source(D)]
+ <- .print("Threat at (",X,",",Y,") neutralized by ",D).
+

--- a/src/agt/drone.asl
+++ b/src/agt/drone.asl
@@ -1,18 +1,23 @@
 { include("$jacamo/templates/common-cartago.asl") }
 
-!inicializar_drone.
+!start.
 
-+!inicializar_drone
- <- makeArtifact("grid","artifacts.PatrolEnv",[500,200,700,500,10],G);
-    focus(G);
-    .print("Drone inicializado: workspace=",G);
-    startPatrol.
++!start
+ <- .my_name(Me);
+    lookupArtifact("grid",Env) | makeArtifact("grid","artifacts.PatrolEnv",[500,200,700,500,10],Env);
+    focus(Env);
+    registerDrone(Me);
+    .send(coord,tell,ready(Me));
+    .print("Drone ",Me," ready.").
 
-+cellScanned(X,Y)
- <- .print("→ Patrulhando Região (",X,",",Y,")").
++gather(X,Y)[source(coord)]
+ <- !goto(X,Y).
 
-+threat(X,Y)
- <- .print("Possivel ameaça detectada na região (",X,",",Y,")").
++threat(X,Y)[source(Env)]
+ <- .send(coord,tell,threat(X,Y)).
 
-+complete
- <- .print("Patrulha completa!").
++!goto(X,Y)
+ <- moveAndScan(me(),X,Y,F);
+    if F then .send(coord,tell,neutralized(X,Y));
+    .print("scanned (",X,",",Y,") threat=",F).
+

--- a/src/env/artifacts/PatrolEnv.java
+++ b/src/env/artifacts/PatrolEnv.java
@@ -1,23 +1,29 @@
 package artifacts;
 
 import cartago.*;
-import java.awt.Point;
-import java.util.HashSet;
-import java.util.Random;
-import java.util.Set;
+import cartago.tools.GUIArtifact;
+import javax.swing.*;
+import java.awt.*;
+import java.util.*;
 
-public class PatrolEnv extends Artifact {
+public class PatrolEnv extends GUIArtifact {
 
     private int  x1, y1, x2, y2;
+    private int  stepX, stepY;
     private final Set<Point> threats = new HashSet<>();
     private final Random rnd = new Random();
+    private final Map<String, Point> drones = new HashMap<>();
+
+    private JFrame frame;
+    private DrawPanel panel;
+    private final int CELL_SIZE = 40;
 
     void init(int x1, int y1, int x2, int y2, int nThreats) {
         this.x1 = x1;  this.y1 = y1;
         this.x2 = x2;  this.y2 = y2;
 
-        int stepX = Math.max(1, (x2 - x1) / 5);
-        int stepY = Math.max(1, (y2 - y1) / 5);
+        stepX = Math.max(1, (x2 - x1) / 5);
+        stepY = Math.max(1, (y2 - y1) / 5);
 
         while (threats.size() < nThreats) {
             int gx = x1 + rnd.nextInt((x2 - x1) / stepX + 1) * stepX;
@@ -26,6 +32,7 @@ public class PatrolEnv extends Artifact {
         }
 
         defineObsProperty("threatsLeft", threats.size());
+        createGUI();
     }
 
     @OPERATION void scan(int x, int y, OpFeedbackParam<Boolean> found) {
@@ -34,6 +41,23 @@ public class PatrolEnv extends Artifact {
             getObsProperty("threatsLeft").updateValue(threats.size());
         }
         found.set(hit);
+    }
+
+    @OPERATION void registerDrone(String name) {
+        drones.put(name, new Point(x1, y1));
+        updatePanel();
+    }
+
+    @OPERATION void moveAndScan(String name, int x, int y, OpFeedbackParam<Boolean> found) {
+        drones.put(name, new Point(x, y));
+        boolean hit = threats.remove(new Point(x, y));
+        if (hit) {
+            getObsProperty("threatsLeft").updateValue(threats.size());
+            signal("threat", x, y);
+        }
+        found.set(hit);
+        signal("droneMoved", name, x, y);
+        updatePanel();
     }
 
     @OPERATION void startPatrol() {
@@ -65,6 +89,59 @@ public class PatrolEnv extends Artifact {
                 }
             }
             execInternalOp("patrolDone");
+        }
+    }
+
+    private void createGUI() {
+        panel = new DrawPanel();
+        frame = new JFrame("Patrol Environment");
+        frame.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
+        frame.add(panel);
+        frame.pack();
+        frame.setVisible(true);
+    }
+
+    private void updatePanel() {
+        if (panel != null) {
+            panel.repaint();
+        }
+    }
+
+    private class DrawPanel extends JPanel {
+        DrawPanel() {
+            int w = ((x2 - x1) / stepX + 1) * CELL_SIZE;
+            int h = ((y2 - y1) / stepY + 1) * CELL_SIZE;
+            setPreferredSize(new Dimension(w, h));
+        }
+
+        protected void paintComponent(Graphics g) {
+            super.paintComponent(g);
+            for (int y = y1; y <= y2; y += stepY) {
+                for (int x = x1; x <= x2; x += stepX) {
+                    int px = (x - x1) / stepX * CELL_SIZE;
+                    int py = (y - y1) / stepY * CELL_SIZE;
+                    g.setColor(Color.LIGHT_GRAY);
+                    g.drawRect(px, py, CELL_SIZE, CELL_SIZE);
+                }
+            }
+
+            g.setColor(Color.RED);
+            for (Point t : threats) {
+                int px = (t.x - x1) / stepX * CELL_SIZE;
+                int py = (t.y - y1) / stepY * CELL_SIZE;
+                g.fillOval(px + 10, py + 10, CELL_SIZE - 20, CELL_SIZE - 20);
+            }
+
+            g.setColor(Color.BLUE);
+            for (Map.Entry<String, Point> e : drones.entrySet()) {
+                Point p = e.getValue();
+                int px = (p.x - x1) / stepX * CELL_SIZE;
+                int py = (p.y - y1) / stepY * CELL_SIZE;
+                g.fillRect(px + 5, py + 5, CELL_SIZE - 10, CELL_SIZE - 10);
+                g.setColor(Color.WHITE);
+                g.drawString(e.getKey(), px + 8, py + 20);
+                g.setColor(Color.BLUE);
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- extend `PatrolEnv` with simple GUI and multi-drone operations
- create new `coordinator.asl` agent
- update `drone.asl` with move logic and communication
- configure agents in `main.jcm` to include coordinator and two drones

## Testing
- `./gradlew test -q` *(fails: Unsupported class file major version 65)*

------
https://chatgpt.com/codex/tasks/task_e_6850c526fb38833382d4fdfe826501e7