### PR TITLE
Fix JaCaMo agent plan syntax

### DIFF
--- a/src/agt/coordinator.asl
+++ b/src/agt/coordinator.asl
@@ -5,8 +5,8 @@
 +!start
  <- makeArtifact("grid","artifacts.PatrolEnv",[500,200,700,500,10],Env);
     focus(Env);
-    startPatrol.
-    .print("Coordinator ready.").
+     startPatrol;
+     .print("Coordinator ready.").
 
 +ready(D)[source(D)]
  <- +drone(D).

--- a/src/agt/drone.asl
+++ b/src/agt/drone.asl
@@ -17,7 +17,8 @@
  <- .send(coord,tell,threat(X,Y)).
 
 +!goto(X,Y)
- <- moveAndScan(me(),X,Y,F);
+ <- .my_name(Me);
+    moveAndScan(Me,X,Y,F);
     if F then .send(coord,tell,neutralized(X,Y));
     .print("scanned (",X,",",Y,") threat=",F).
 


### PR DESCRIPTION
## Summary
- fix coordinator start plan so `.print` isn't interpreted as a belief
- correct drone goto plan and remove invalid `me()` term

## Testing
- `./gradlew test`
- `timeout 5 ./gradlew run < /dev/null`

------
https://chatgpt.com/codex/tasks/task_e_6850e425754083339ecc0c49006e3597