### PR TITLE
Fix drone navigation

### DIFF
--- a/src/agt/drone.asl
+++ b/src/agt/drone.asl
@@ -20,11 +20,11 @@ my_name(drone1).
 <-  .print("Low battery (",Lvl,") – heading to charger.");
     position(N,X0,Y0);
     nearestCharger(X0,Y0,CX,CY);
-    navigate(N,CX,CY,_).
+    simpleNavigate(N,CX,CY,_).
 
 +!scan_cell(X,Y)
  <- ?my_name(N);
-    navigate(N,X,Y,Arrived);
+     simpleNavigate(N,X,Y,Arrived);
     !handle_arrival(N,X,Y,Arrived).
 
 +!handle_arrival(N,X,Y,true)


### PR DESCRIPTION
## Summary
- add a `simpleNavigate` operation in `PatrolEnv`
- use the simple navigation in `drone.asl`

## Testing
- `./gradlew testJaCaMo -Djava.awt.headless=true`

------
https://chatgpt.com/codex/tasks/task_e_685d24aec47483338a8cae1b099e02a1