### PR TITLE
Fix drone env lookup

### DIFF
--- a/src/agt/drone_multi.asl
+++ b/src/agt/drone_multi.asl
@@ -1,14 +1,21 @@
-my_name(Name).
-
 !start.
 
+
 +!start
+ <- .my_name(N);
+    +my_name(N);
+    !!connect_env(N).
+
++!connect_env(N)
  <- lookupArtifact("env",EnvID);
     focus(EnvID);
-    ?my_name(N);
     registerDrone(N);
     .print("Drone ",N," ready.");
     .send(central, tell, ready).
+
++!connect_env(N)[error(action_failed)]
+ <- .wait(500);
+    !!connect_env(N).
 
 +target(N,X,Y)[source(env)] : my_name(N)
  <- .print("Moving to target (",X,",",Y,")");


### PR DESCRIPTION
## Summary
- handle env not being available at drone start by retrying `lookupArtifact`

## Testing
- `./gradlew test --console=plain` *(fails: Unsupported class file major version 65)*

------
https://chatgpt.com/codex/tasks/task_e_685d4401ea308333ac90fe1b4c4f77f6